### PR TITLE
test: add tsx test

### DIFF
--- a/tests/__snapshots__/esbuild.test.ts.snap
+++ b/tests/__snapshots__/esbuild.test.ts.snap
@@ -3,12 +3,19 @@
 exports[`esbuild > generate mode 1`] = `
 [
   "// <stdout>
+// tests/fixtures/component.tsx
+function Component() {
+  return /* @__PURE__ */ React.createElement("div", null, "I'm a div in a tsx component!");
+}
+
 // tests/fixtures/main.ts
 function hello(s) {
   return "hello" + s;
 }
+var c = Component;
 var num = 1;
 export {
+  c,
   hello,
   num
 };
@@ -17,6 +24,7 @@ export {
 import { type Num } from './types';
 export type Str = string;
 export declare function hello(s: Str): Str;
+export declare let c: React.JSX.Element;
 export declare let num: Num;
 ",
   "// temp/types.d.ts
@@ -33,6 +41,7 @@ exports[`esbuild > write mode 1`] = `
   "import { type Num } from './types';
 export type Str = string;
 export declare function hello(s: Str): Str;
+export declare let c: React.JSX.Element;
 export declare let num: Num;
 ",
   "export type Num = number;

--- a/tests/__snapshots__/rolldown.test.ts.snap
+++ b/tests/__snapshots__/rolldown.test.ts.snap
@@ -3,19 +3,28 @@
 exports[`rolldown 1`] = `
 [
   "// main.js
+import { jsx as _jsx } from "react/jsx-runtime";
 
+//#region tests/fixtures/component.tsx
+function Component() {
+	return _jsx("div", { children: "I'm a div in a tsx component!" });
+}
+
+//#endregion
 //#region tests/fixtures/main.ts
 function hello(s) {
 	return "hello" + s;
 }
+let c = Component;
 let num = 1;
 
 //#endregion
-export { hello, num };",
+export { c, hello, num };",
   "// temp/main.d.ts
 import { type Num } from "./types";
 export type Str = string;
 export declare function hello(s: Str): Str;
+export declare let c: React.JSX.Element;
 export declare let num: Num;
 ",
   "// temp/types.d.ts

--- a/tests/__snapshots__/rollup.test.ts.snap
+++ b/tests/__snapshots__/rollup.test.ts.snap
@@ -3,17 +3,23 @@
 exports[`rollup 1`] = `
 [
   "// main.js
+function Component() {
+  return /* @__PURE__ */ React.createElement("div", null, "I'm a div in a tsx component!");
+}
+
 function hello(s) {
   return "hello" + s;
 }
+let c = Component;
 let num = 1;
 
-export { hello, num };
+export { c, hello, num };
 ",
   "// temp/main.d.ts
 import { type Num } from './types';
 export type Str = string;
 export declare function hello(s: Str): Str;
+export declare let c: React.JSX.Element;
 export declare let num: Num;
 ",
   "// temp/types.d.ts

--- a/tests/fixtures/component.tsx
+++ b/tests/fixtures/component.tsx
@@ -1,0 +1,3 @@
+export function Component(): React.JSX.Element {
+  return <div>I'm a div in a tsx component!</div>
+}

--- a/tests/fixtures/main.ts
+++ b/tests/fixtures/main.ts
@@ -1,8 +1,11 @@
 import { type Num } from './types'
+import { Component } from './component'
 export type Str = string
 
 export function hello(s: Str): Str {
   return 'hello' + s
 }
+
+export let c: React.JSX.Element = Component
 
 export let num: Num = 1


### PR DESCRIPTION
### Description

This plugin does not yet work with tsx files, even though the supporting libraries (such as rollup-plugin-dts) do support them. This PR adds a .tsx file to the test fixtures, and the follow-up PR will update the test snapshots appropriately.

NOTE: The snapshots are WRONG right now. They don't contain a component.d.ts file. The next PR will fix that.

### Linked Issues
n/a

### Additional context
n/a
