### PR TITLE
feat: tsx file support

### DIFF
--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -40,7 +40,7 @@ export type OptionsResolved = Overwrite<
 
 export function resolveOptions(options: Options): OptionsResolved {
   return {
-    include: options.include || [/\.[cm]?ts$/],
+    include: options.include || [/\.[cm]?tsx?$/],
     exclude: options.exclude || [/node_modules/],
     enforce: 'enforce' in options ? options.enforce : 'pre',
     transformer: options.transformer || 'typescript',

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ export const IsolatedDecl: UnpluginInstance<Options | undefined, false> =
         }
 
         let entryFileNames = outputOptions.entryFileNames.replace(
-          /\.(.)?[jt]s$/,
+          /\.(.)?[jt]sx?$/,
           (_, s) => `.d.${s || ''}ts`,
         )
 
@@ -122,7 +122,7 @@ export const IsolatedDecl: UnpluginInstance<Options | undefined, false> =
 
           const resolved = await resolve(context, i.source.value, id)
           if (!resolved || resolved.external) continue
-          if (resolved.id.endsWith('.ts')) {
+          if (resolved.id.endsWith('.ts') || resolved.id.endsWith('.tsx')) {
             s.overwrite(
               // @ts-expect-error
               i.source.start,
@@ -296,7 +296,7 @@ async function resolve(
 }
 
 function stripExt(filename: string) {
-  return filename.replace(/\.(.?)[jt]s$/, '')
+  return filename.replace(/\.(.?)[jt]sx?$/, '')
 }
 
 function patchCjsDefaultExport(source: string) {

--- a/tests/__snapshots__/esbuild.test.ts.snap
+++ b/tests/__snapshots__/esbuild.test.ts.snap
@@ -3,12 +3,19 @@
 exports[`esbuild > generate mode 1`] = `
 [
   "// <stdout>
+// tests/fixtures/component.tsx
+function Component() {
+  return /* @__PURE__ */ React.createElement("div", null, "I'm a div in a tsx component!");
+}
+
 // tests/fixtures/main.ts
 function hello(s) {
   return "hello" + s;
 }
+var c = Component;
 var num = 1;
 export {
+  c,
   hello,
   num
 };
@@ -17,6 +24,7 @@ export {
 import { type Num } from './types';
 export type Str = string;
 export declare function hello(s: Str): Str;
+export declare let c: React.JSX.Element;
 export declare let num: Num;
 ",
   "// temp/types.d.ts
@@ -25,14 +33,20 @@ export type Num = number;
   "// temp/types2.d.ts
 export type Num2 = number;
 ",
+  "// temp/component.d.ts
+export declare function Component(): React.JSX.Element;
+",
 ]
 `;
 
 exports[`esbuild > write mode 1`] = `
 [
+  "export declare function Component(): React.JSX.Element;
+",
   "import { type Num } from './types';
 export type Str = string;
 export declare function hello(s: Str): Str;
+export declare let c: React.JSX.Element;
 export declare let num: Num;
 ",
   "export type Num = number;

--- a/tests/__snapshots__/rolldown.test.ts.snap
+++ b/tests/__snapshots__/rolldown.test.ts.snap
@@ -3,19 +3,31 @@
 exports[`rolldown 1`] = `
 [
   "// main.js
+import { jsx as _jsx } from "react/jsx-runtime";
 
+//#region tests/fixtures/component.tsx
+function Component() {
+	return _jsx("div", { children: "I'm a div in a tsx component!" });
+}
+
+//#endregion
 //#region tests/fixtures/main.ts
 function hello(s) {
 	return "hello" + s;
 }
+let c = Component;
 let num = 1;
 
 //#endregion
-export { hello, num };",
+export { c, hello, num };",
+  "// temp/component.d.ts
+export declare function Component(): React.JSX.Element;
+",
   "// temp/main.d.ts
 import { type Num } from "./types";
 export type Str = string;
 export declare function hello(s: Str): Str;
+export declare let c: React.JSX.Element;
 export declare let num: Num;
 ",
   "// temp/types.d.ts

--- a/tests/__snapshots__/rollup.test.ts.snap
+++ b/tests/__snapshots__/rollup.test.ts.snap
@@ -3,17 +3,23 @@
 exports[`rollup 1`] = `
 [
   "// main.js
+function Component() {
+  return /* @__PURE__ */ React.createElement("div", null, "I'm a div in a tsx component!");
+}
+
 function hello(s) {
   return "hello" + s;
 }
+let c = Component;
 let num = 1;
 
-export { hello, num };
+export { c, hello, num };
 ",
   "// temp/main.d.ts
 import { type Num } from './types';
 export type Str = string;
 export declare function hello(s: Str): Str;
+export declare let c: React.JSX.Element;
 export declare let num: Num;
 ",
   "// temp/types.d.ts
@@ -21,6 +27,9 @@ export type Num = number;
 ",
   "// temp/types2.d.ts
 export type Num2 = number;
+",
+  "// temp/component.d.ts
+export declare function Component(): React.JSX.Element;
 ",
 ]
 `;

--- a/tests/fixtures/component.tsx
+++ b/tests/fixtures/component.tsx
@@ -1,0 +1,3 @@
+export function Component(): React.JSX.Element {
+  return <div>I'm a div in a tsx component!</div>
+}

--- a/tests/fixtures/main.ts
+++ b/tests/fixtures/main.ts
@@ -1,8 +1,11 @@
 import { type Num } from './types'
+import { Component } from './component'
 export type Str = string
 
 export function hello(s: Str): Str {
   return 'hello' + s
 }
+
+export let c: React.JSX.Element = Component
 
 export let num: Num = 1


### PR DESCRIPTION
### Description

This plugin does not yet work with tsx files, even though the supporting libraries (such as rollup-plugin-dts) do support them. This PR adds a .tsx files. I've added a tsx file to the fixtures and made sure the snapshots reflect that, with this PR, a component.d.ts file gets generated from the component.tsx file (before it would get referenced as an import but no .d.ts file would be generated).

### Linked Issues
n/a

### Additional context
n/a
