### PR TITLE
fix: support object input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ export const IsolatedDecl: UnpluginInstance<Options | undefined, false> =
         input = typeof input === 'string' ? [input] : input
         if (Array.isArray(input)) {
           outBase = lowestCommonAncestor(...input)
+        } else if (typeof input === 'object') {
+          outBase = lowestCommonAncestor(...Object.values(input))
         }
 
         if (typeof outputOptions.entryFileNames !== 'string') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,14 +35,14 @@ export const IsolatedDecl: UnpluginInstance<Options | undefined, false> =
 
     const rollup: Partial<Plugin> = {
       renderStart(outputOptions, inputOptions) {
-        let outBase = ''
-        let input = inputOptions.input
-        input = typeof input === 'string' ? [input] : input
-        if (Array.isArray(input)) {
-          outBase = lowestCommonAncestor(...input)
-        } else if (typeof input === 'object') {
-          outBase = lowestCommonAncestor(...Object.values(input))
-        }
+        const { input } = inputOptions
+        const normalizedInput =
+          typeof input === 'string'
+            ? [input]
+            : Array.isArray(input)
+              ? input
+              : Object.values(input)
+        const outBase = lowestCommonAncestor(...normalizedInput)
 
         if (typeof outputOptions.entryFileNames !== 'string') {
           return this.error('entryFileNames must be a string')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

[Input maps](https://rollupjs.org/configuration-options/#input) weren't being considered when resolving the lowest common ancestor among the entry points.

### Linked Issues

Here's a repro: https://github.com/AdrianGonz97/dts-input-maps-repro

1. Clone repo
2. Install dependencies `pnpm i`
3. Run `pnpm build`

If you look at the resulting `dist` directory, you'll notice how it contains `packages/foo`, meaning that the dts generation wasn't scoped to the correct directory

### Additional context

As an aside, it would be nice if the generated entry points got their own `.d.ts` files as well, but I think that's a separate issue.
