### PR TITLE
feat: support oxc `stripInternal` option

### DIFF
--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -1,3 +1,4 @@
+import type { IsolatedDeclarationsOptions } from 'oxc-transform'
 import type { TranspileOptions } from 'typescript'
 import type { FilterPattern } from 'unplugin-utils'
 
@@ -30,10 +31,16 @@ export type Options = {
 } & (
   | {
       /**
-       * `oxc-transform` or `@swc/core` should be installed yourself
-       * if you want to use `oxc` or `swc` transformer.
+       * `@swc/core` should be installed yourself.
        */
-      transformer?: 'oxc' | 'swc'
+      transformer?: 'swc'
+    }
+  | {
+      /**
+       * `oxc-transform` should be installed yourself.
+       */
+      transformer?: 'oxc'
+      transformOptions?: Omit<IsolatedDeclarationsOptions, 'sourceMap'>
     }
   | {
       /**
@@ -49,7 +56,7 @@ export type Options = {
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
 
 export type OptionsResolved = Overwrite<
-  Required<Options>,
+  Required<Options> & { transformOptions?: any },
   Pick<Options, 'enforce' | 'extraOutdir' | 'rewriteImports' | 'inputBase'>
 >
 
@@ -65,5 +72,6 @@ export function resolveOptions(options: Options): OptionsResolved {
     patchCjsDefaultExport: options.patchCjsDefaultExport || false,
     rewriteImports: options.rewriteImports,
     inputBase: options.inputBase,
+    transformOptions: (options as any).transformOptions,
   }
 }

--- a/src/core/transformer.ts
+++ b/src/core/transformer.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import type { IsolatedDeclarationsOptions } from 'oxc-transform'
 import type { CompilerOptions, TranspileOptions } from 'typescript'
 
 export interface TransformResult {
@@ -17,7 +18,7 @@ function tryImport<T>(pkg: string): Promise<T | null> {
 export async function oxcTransform(
   id: string,
   code: string,
-  sourceMap?: boolean,
+  transformOptions?: IsolatedDeclarationsOptions,
 ): Promise<TransformResult> {
   const oxc = await tryImport<typeof import('oxc-transform')>('oxc-transform')
   if (!oxc) {
@@ -28,7 +29,7 @@ export async function oxcTransform(
       ],
     }
   }
-  const result = oxc.isolatedDeclaration(id, code, { sourcemap: sourceMap })
+  const result = oxc.isolatedDeclaration(id, code, transformOptions)
   return {
     ...result,
     map: result.map?.mappings,

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,10 @@ export const IsolatedDecl: UnpluginInstance<Options | undefined, false> =
       let result: TransformResult
       switch (options.transformer) {
         case 'oxc':
-          result = await oxcTransform(id, code, options.sourceMap)
+          result = await oxcTransform(id, code, {
+            ...options.transformOptions,
+            sourcemap: options.sourceMap,
+          })
           break
         case 'swc':
           result = await swcTransform(id, code)
@@ -123,7 +126,7 @@ export const IsolatedDecl: UnpluginInstance<Options | undefined, false> =
           result = await tsTransform(
             id,
             code,
-            (options as any).transformOptions,
+            options.transformOptions,
             options.sourceMap,
           )
           break

--- a/tests/__snapshots__/rollup/oxc-options.md
+++ b/tests/__snapshots__/rollup/oxc-options.md
@@ -1,0 +1,20 @@
+## main.d.ts
+
+```ts
+export declare class Test {
+	show(): void;
+}
+
+```
+## main.js
+
+```js
+class Test {
+	show() {}
+	/** @internal */
+	hide() {}
+}
+
+export { Test };
+
+```

--- a/tests/fixtures/oxc-options/main.ts
+++ b/tests/fixtures/oxc-options/main.ts
@@ -1,0 +1,6 @@
+export class Test {
+  show(): void { }
+
+  /** @internal */
+  hide() { }
+}

--- a/tests/rollup.test.ts
+++ b/tests/rollup.test.ts
@@ -167,4 +167,26 @@ describe.concurrent('rollup', () => {
 
     await expectSnapshot(dist, `rollup/${dir}`, expect)
   })
+
+  test('oxc options', async ({ expect }) => {
+    const dir = 'oxc-options'
+    const input = path.resolve(fixtures, dir, 'main.ts')
+    const dist = path.resolve(TEST_SANDBOX_FOLDER, dir)
+
+    const bundle = await rollup({
+      input,
+      plugins: [
+        UnpluginIsolatedDecl({
+          transformer: 'oxc',
+          transformOptions: { stripInternal: true },
+        }),
+        Oxc(),
+      ],
+      logLevel: 'silent',
+    })
+
+    await bundle.write({ dir: dist })
+
+    await expectSnapshot(dist, `rollup/${dir}`, expect)
+  })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Oxc isolated decl transform supports `stripInternal` https://github.com/oxc-project/oxc/pull/5878, which works like tsconfig's `stripInternal` https://www.typescriptlang.org/tsconfig/#stripInternal. This option wasn't exposed yet from this unplugin, so I added it when `transformer: "oxc"` is used.

### Linked Issues


### Additional context

Probably you've seen on Vitest repo https://github.com/vitest-dev/vitest/pull/7472 where we have some `/** @internal */` methods without return type specified on `package/vite-node` and `packages/vitest`. Not sure we'll get that part first, but hopefully it helps soon.
